### PR TITLE
test: Enable `force_destroy` on `dns-delegated` test fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,20 +202,21 @@ atmos terraform apply amplify/example -s <stack>
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 2.0.0, < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
-
+| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 2.0.0, < 3.0.0 |
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_amplify_app"></a> [amplify\_app](#module\_amplify\_app) | cloudposse/amplify-app/aws | 1.2.0 |
 | <a name="module_certificate_verification_dns_record"></a> [certificate\_verification\_dns\_record](#module\_certificate\_verification\_dns\_record) | cloudposse/route53-cluster-hostname/aws | 0.13.0 |
-| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_subdomains_dns_record"></a> [subdomains\_dns\_record](#module\_subdomains\_dns\_record) | cloudposse/route53-cluster-hostname/aws | 0.13.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/src/README.md
+++ b/src/README.md
@@ -150,20 +150,21 @@ atmos terraform apply amplify/example -s <stack>
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 2.0.0, < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
-
+| <a name="provider_utils"></a> [utils](#provider\_utils) | >= 2.0.0, < 3.0.0 |
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_amplify_app"></a> [amplify\_app](#module\_amplify\_app) | cloudposse/amplify-app/aws | 1.2.0 |
 | <a name="module_certificate_verification_dns_record"></a> [certificate\_verification\_dns\_record](#module\_certificate\_verification\_dns\_record) | cloudposse/route53-cluster-hostname/aws | 0.13.0 |
-| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_subdomains_dns_record"></a> [subdomains\_dns\_record](#module\_subdomains\_dns\_record) | cloudposse/route53-cluster-hostname/aws | 0.13.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "dns_delegated" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = var.dns_delegated_component_name
   environment = var.dns_delegated_environment_name

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.9.0, < 6.0.0"
     }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 2.0.0, < 3.0.0"
+    }
   }
 }

--- a/test/fixtures/stacks/catalog/dns-delegated.yaml
+++ b/test/fixtures/stacks/catalog/dns-delegated.yaml
@@ -8,3 +8,4 @@ components:
           - subdomain: test
             zone_name: example.net
         request_acm_certificate: false
+        force_destroy: true

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   sources:
     - component: "account-map"
-      source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
-      version: 1.520.0
+      source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -31,7 +31,7 @@ spec:
 
     - component: "dns-delegated"
       source: github.com/cloudposse-terraform-components/aws-dns-delegated.git//src?ref={{.Version}}
-      version: v1.535.1
+      version: v1.537.1
       targets:
         - "components/terraform/dns-delegated"
       included_paths:

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -31,7 +31,7 @@ spec:
 
     - component: "dns-delegated"
       source: github.com/cloudposse-terraform-components/aws-dns-delegated.git//src?ref={{.Version}}
-      version: v1.537.1
+      version: v1.537.2
       targets:
         - "components/terraform/dns-delegated"
       included_paths:


### PR DESCRIPTION
## what
* Bump `dns-delegated` test fixture component version in `test/fixtures/vendor.yaml` to `v1.537.1` (includes `force_destroy` support from https://github.com/cloudposse-terraform-components/aws-dns-delegated/pull/71)
* Set `force_destroy: true` on `dns-delegated` in `test/fixtures/stacks/catalog/dns-delegated.yaml`

## why
* Fixes `HostedZoneNotEmpty` teardown failure during Terratest runs caused by Route 53 subdomain / verification records created by Amplify that are not managed by Terraform state.